### PR TITLE
Add public standings page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fantastats – Albo d'oro</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="container">
+        <h1>Fantastats</h1>
+        <p class="subtitle">Albo d'oro del nostro fantacalcio</p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="card">
+        <header class="card__header">
+          <h2>Classifiche recenti</h2>
+          <p id="status" data-status class="status">Caricamento in corso…</p>
+        </header>
+
+        <div class="table-wrapper">
+          <table id="rankings" aria-describedby="status">
+            <thead>
+              <tr>
+                <th scope="col">Stagione</th>
+                <th scope="col">Posizione</th>
+                <th scope="col">Allenatore</th>
+                <th scope="col">Squadra</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      <div class="container">
+        <p>
+          Dati aggiornati dal foglio Google condiviso tra i partecipanti.
+          <span id="updated-at" hidden>Ultimo aggiornamento: <time></time></span>
+        </p>
+      </div>
+    </footer>
+
+    <script src="main.js" type="module"></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,159 @@
+const API_URL =
+  'https://script.googleusercontent.com/macros/echo?user_content_key=AehSKLgOBXDvnu7qLY88z22P3W3x2d9EieIsBcx5hQihk5a7j1cenYJgDbP-7PQOFV9nC7X0ex6n34ssEQLnuApVc8Kt_TM9sRZEUWXxrn4qKIx7_XlUGJQfB-WmnYy_8oLlOwsnMrrbT6hZxTSVm8YWYvw9SWyA_bkxjWZy0z_N_e9JuFm-i_kxEfFKK8figoWdK0yt7Go9rVKug9CyfutNEViIW7LzLqrTgM3RaC8E-7qZdUXTVkrTIhFt7Y2TwA&lib=Me_TdFWiyl3TASNz2Bx8Jo7Bo4TGvA1H8';
+
+const statusElement = document.querySelector('[data-status]');
+const tableBody = document.querySelector('#rankings tbody');
+const updatedAtContainer = document.querySelector('#updated-at');
+const updatedAtTime = updatedAtContainer?.querySelector('time');
+
+const KEY_MAP = {
+  season: ['Stagione', 'Season', 'Anno', 'Year'],
+  position: ['Posizione', 'Placement', 'Position', 'Rank'],
+  coach: ['Allenatore', 'Manager', 'Coach'],
+  team: ['Squadra', 'Team', 'Club'],
+};
+
+function resolveKey(record, candidates) {
+  return candidates.find((key) => Object.prototype.hasOwnProperty.call(record, key));
+}
+
+function normalizeValue(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return value;
+}
+
+function buildPositionBadge(positionRaw) {
+  const position = normalizeValue(positionRaw);
+  if (!position && position !== 0) {
+    return '';
+  }
+
+  const wrapper = document.createElement('span');
+  wrapper.className = 'badge';
+
+  const medal =
+    position === 1 || position === '1' || position === '1°'
+      ? '🥇'
+      : position === 2 || position === '2' || position === '2°'
+      ? '🥈'
+      : position === 3 || position === '3' || position === '3°'
+      ? '🥉'
+      : '🏅';
+
+  const label = typeof position === 'number' ? `${position}°` : position;
+  wrapper.textContent = `${medal} ${label}`;
+  return wrapper.outerHTML;
+}
+
+function renderRow(record, keyNames) {
+  const seasonValue = normalizeValue(record[keyNames.season]);
+  const positionValue = normalizeValue(record[keyNames.position]);
+  const coachValue = normalizeValue(record[keyNames.coach]);
+  const teamValue = normalizeValue(record[keyNames.team]);
+
+  const row = document.createElement('tr');
+
+  const columns = [
+    { label: 'Stagione', value: seasonValue },
+    { label: 'Posizione', value: buildPositionBadge(positionValue) },
+    {
+      label: 'Allenatore',
+      value: coachValue,
+      emptyText: 'Allenatore da definire',
+    },
+    { label: 'Squadra', value: teamValue, emptyText: 'Squadra non registrata' },
+  ];
+
+  columns.forEach(({ label, value, emptyText }) => {
+    const cell = document.createElement('td');
+    cell.dataset.label = label;
+    if (value) {
+      cell.innerHTML = value;
+    } else {
+      cell.dataset.empty = 'true';
+      cell.textContent = emptyText ?? 'Dato mancante';
+    }
+    row.append(cell);
+  });
+
+  return row;
+}
+
+function parseYear(value) {
+  const normalized = normalizeValue(value);
+  if (!normalized) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  if (typeof normalized === 'number') {
+    return normalized;
+  }
+
+  const matches = normalized.match(/\d{4}/g);
+  if (!matches) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  return parseInt(matches[0], 10);
+}
+
+async function loadRankings() {
+  try {
+    statusElement.textContent = 'Caricamento in corso…';
+    const response = await fetch(API_URL);
+    if (!response.ok) {
+      throw new Error(`Richiesta fallita (${response.status})`);
+    }
+
+    const payload = await response.json();
+    if (!Array.isArray(payload) || payload.length === 0) {
+      statusElement.textContent = 'Nessun dato disponibile al momento.';
+      return;
+    }
+
+    const sample = payload[0];
+    const keyNames = {
+      season: resolveKey(sample, KEY_MAP.season),
+      position: resolveKey(sample, KEY_MAP.position),
+      coach: resolveKey(sample, KEY_MAP.coach),
+      team: resolveKey(sample, KEY_MAP.team),
+    };
+
+    if (!keyNames.season || !keyNames.position || !keyNames.coach || !keyNames.team) {
+      statusElement.textContent =
+        'Formato dati inatteso: controlla le intestazioni del foglio.';
+      return;
+    }
+
+    const sorted = [...payload].sort((a, b) =>
+      parseYear(b[keyNames.season]) - parseYear(a[keyNames.season]) ||
+      parseInt(a[keyNames.position], 10) - parseInt(b[keyNames.position], 10)
+    );
+
+    tableBody.replaceChildren(...sorted.map((record) => renderRow(record, keyNames)));
+    statusElement.textContent = `Totale stagioni registrate: ${new Set(
+      sorted.map((record) => normalizeValue(record[keyNames.season]))
+    ).size}`;
+
+    if (updatedAtTime) {
+      const now = new Date();
+      updatedAtTime.dateTime = now.toISOString();
+      updatedAtTime.textContent = new Intl.DateTimeFormat('it-IT', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(now);
+      updatedAtContainer.hidden = false;
+    }
+  } catch (error) {
+    console.error(error);
+    statusElement.textContent =
+      'Impossibile recuperare i dati. Riprova tra qualche minuto.';
+  }
+}
+
+loadRankings();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,190 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Nunito', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  --bg: #f5f6fa;
+  --card-bg: #ffffffcc;
+  --text: #1f2933;
+  --muted: #52606d;
+  --accent: #2563eb;
+  --border: rgba(31, 41, 51, 0.12);
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.page-header {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: white;
+  padding: 2.5rem 1rem;
+  box-shadow: 0 12px 24px rgba(29, 78, 216, 0.35);
+  margin-bottom: 2.5rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.page-header .subtitle {
+  margin: 0.5rem 0 0;
+  font-weight: 500;
+  font-size: 1.1rem;
+  opacity: 0.9;
+}
+
+.container {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+}
+
+.card {
+  background: var(--card-bg);
+  backdrop-filter: blur(6px);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  margin-bottom: 2rem;
+  border: 1px solid var(--border);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.card__header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.table-wrapper {
+  margin-top: 1.5rem;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+thead {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+thead th {
+  text-align: left;
+  font-weight: 700;
+  padding: 0.85rem 1rem;
+  color: #1d4ed8;
+  letter-spacing: 0.03em;
+  font-size: 0.9rem;
+}
+
+tbody tr:not(:last-child) {
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+td {
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+}
+
+td:first-child {
+  font-weight: 600;
+  color: #111827;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 0.1rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+[data-empty="true"] {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.page-footer {
+  margin-top: 3rem;
+  padding: 2rem 1rem 3rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.page-footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.25rem;
+  }
+
+  thead {
+    display: none;
+  }
+
+  table,
+  tbody,
+  tr,
+  td {
+    display: block;
+    width: 100%;
+  }
+
+  tbody tr {
+    margin-bottom: 1.25rem;
+    border-radius: 12px;
+    box-shadow: 0 12px 18px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    overflow: hidden;
+  }
+
+  td {
+    padding: 0.75rem;
+    position: relative;
+  }
+
+  td::before {
+    content: attr(data-label);
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: #2563eb;
+    margin-bottom: 0.35rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static index page to present the fantacalcio standings with placeholders for missing data
- implement responsive styling for the layout, table and badges
- load rankings from the published Google Apps Script endpoint and render them dynamically

## Testing
- no automated tests were run (static front-end only)


------
https://chatgpt.com/codex/tasks/task_e_68c93106a854832085167d69022d2de3