### PR TITLE
Adjust medal badge layout to match mockup

### DIFF
--- a/main.js
+++ b/main.js
@@ -193,28 +193,28 @@ function renderMedalsPodium(topCoaches) {
     goldStat.className = 'badge-stat';
     goldStat.innerHTML = `
       <div class="badge-stat-value">${coach.gold}</div>
-      <div>ORO</div>
+      <div class="badge-stat-label">ORO</div>
     `;
 
     const silverStat = document.createElement('div');
     silverStat.className = 'badge-stat';
     silverStat.innerHTML = `
       <div class="badge-stat-value">${coach.silver}</div>
-      <div>ARG</div>
+      <div class="badge-stat-label">ARG</div>
     `;
 
     const bronzeStat = document.createElement('div');
     bronzeStat.className = 'badge-stat';
     bronzeStat.innerHTML = `
       <div class="badge-stat-value">${coach.bronze}</div>
-      <div>BRON</div>
+      <div class="badge-stat-label">BRON</div>
     `;
 
     const totalStat = document.createElement('div');
     totalStat.className = 'badge-stat';
     totalStat.innerHTML = `
       <div class="badge-stat-value">${coach.total}</div>
-      <div>TOT</div>
+      <div class="badge-stat-label">TOT</div>
     `;
 
     stats.append(goldStat, silverStat, bronzeStat, totalStat);
@@ -277,7 +277,12 @@ async function loadRankings() {
 
     // Calcola e mostra la classifica medaglie
     const medalsRanking = calculateMedals(payload, keyNames);
-    renderMedalsPodium(medalsRanking);
+    const medalsRankingWithImages = medalsRanking.map((entry) => ({
+      ...entry,
+      image: coachImages?.[entry.coach] ?? null,
+    }));
+
+    renderMedalsPodium(medalsRankingWithImages);
     medalsStatusElement.textContent = `Classifica aggiornata: ${medalsRanking.length} allenatori`;
 
     // Mostra la tabella delle classifiche recenti

--- a/styles.css
+++ b/styles.css
@@ -118,7 +118,7 @@ body {
 /* Badge senza contenitore esterno */
 .podium-card {
   position: relative;
-  width: 200px;
+  width: 220px;
   max-width: 100%;
   display: inline-block;
 }
@@ -127,70 +127,72 @@ body {
   display: block;
   width: 100%;
   height: auto;
-  border-radius: 12px;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
 }
 
 .coach-photo {
   position: absolute;
   left: 50%;
-  top: 20%;
+  top: 32%;
   transform: translate(-50%, -50%);
-  width: 40%;
+  width: 56%;
   aspect-ratio: 1 / 1;
   border-radius: 50%;
   overflow: hidden;
   object-fit: cover;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9), 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.95), 0 4px 18px rgba(0, 0, 0, 0.18);
 }
 
 /* Testo sovrapposto sui badge - parte bassa */
 .badge-content {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 0.4rem 0.6rem 0.6rem;
-  background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
-  border-radius: 0 0 12px 12px;
-  color: white;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
-  overflow: hidden;
+  left: 50%;
+  bottom: 12%;
+  transform: translateX(-50%);
+  width: 78%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.65rem;
+  color: #fff;
+  text-align: center;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
 }
 
 .badge-coach-name {
-  font-size: 0.8rem;
+  font-size: 1rem;
   font-weight: 700;
-  margin-bottom: 0.2rem;
+  margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  text-align: center;
-  line-height: 1.1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  white-space: normal;
 }
 
 .badge-stats {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.65rem;
-  font-weight: 600;
-  gap: 0.2rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  width: 100%;
+  gap: 0.35rem;
+  text-transform: uppercase;
 }
 
 .badge-stat {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.05rem;
-  flex: 1;
-  min-width: 0;
+  gap: 0.25rem;
 }
 
 .badge-stat-value {
-  font-size: 0.75rem;
+  font-size: 1.05rem;
   font-weight: 700;
+  line-height: 1;
+}
+
+.badge-stat-label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
 }
 
 .podium-position {
@@ -331,30 +333,30 @@ td:first-child {
   }
 
   .podium-card {
-    width: 180px;
+    width: 200px;
   }
 
   .coach-photo {
-    width: 35%;
-    top: 18%;
+    top: 34%;
+    width: 60%;
   }
 
   .badge-content {
-    padding: 0.3rem 0.5rem 0.5rem;
+    bottom: 10%;
+    width: 86%;
+    gap: 0.5rem;
   }
 
   .badge-coach-name {
-    font-size: 0.75rem;
-    margin-bottom: 0.15rem;
-  }
-
-  .badge-stats {
-    font-size: 0.6rem;
-    gap: 0.15rem;
+    font-size: 0.9rem;
   }
 
   .badge-stat-value {
-    font-size: 0.7rem;
+    font-size: 0.95rem;
+  }
+
+  .badge-stat-label {
+    font-size: 0.52rem;
   }
 
   .podium-stats {


### PR DESCRIPTION
## Summary
- reposition the badge text to mirror the provided mockup layout and remove the lower gradient overlay
- surface optional coach portraits on podium badges and expand styling to highlight stats labels

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d711a8cb5483209dd155f207c31762