### PR TITLE
Use drop shadow for coach photo

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,7 +137,7 @@ body {
   transform: translateX(-50%);
   width: 60%;
   object-fit: cover;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.22);
+  filter: drop-shadow(0 12px 28px rgba(15, 23, 42, 0.22));
 }
 
 /* Testo sovrapposto sui badge - parte bassa */


### PR DESCRIPTION
## Summary
- replace the coach photo box shadow with a drop-shadow filter so the outline matches the transparent image

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d803e5c5048320b61141654f421226