### PR TITLE
Split rankings content into dedicated page

### DIFF
--- a/classifiche.html
+++ b/classifiche.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fantastats – Classifiche</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="container">
+        <h1>Fantastats</h1>
+        <p class="subtitle">Albo d'oro del nostro fantacalcio</p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="card card--hero">
+        <header class="card__header">
+          <h2>Classifica Allenatori per Medaglie</h2>
+          <p id="medals-status" data-status class="status">Caricamento in corso…</p>
+        </header>
+
+        <div id="medals-podium" class="podium">
+          <!-- I primi 3 allenatori verranno inseriti qui -->
+        </div>
+      </section>
+
+      <section class="card">
+        <header class="card__header">
+          <h2>Classifiche recenti</h2>
+          <p id="status" data-status class="status">Caricamento in corso…</p>
+        </header>
+
+        <div class="table-wrapper">
+          <table id="rankings" aria-describedby="status">
+            <thead>
+              <tr>
+                <th scope="col">Stagione</th>
+                <th scope="col">Posizione</th>
+                <th scope="col">Allenatore</th>
+                <th scope="col">Squadra</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      <div class="container">
+        <p>
+          Dati aggiornati dal foglio Google condiviso tra i partecipanti.
+          <span id="updated-at" hidden>Ultimo aggiornamento: <time></time></span>
+        </p>
+      </div>
+    </footer>
+
+    <script src="main.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -23,46 +23,20 @@
     <main class="container">
       <section class="card card--hero">
         <header class="card__header">
-          <h2>Classifica Allenatori per Medaglie</h2>
-          <p id="medals-status" data-status class="status">Caricamento in corso…</p>
+          <h2>Benvenuto!</h2>
         </header>
-
-        <div id="medals-podium" class="podium">
-          <!-- I primi 3 allenatori verranno inseriti qui -->
-        </div>
-      </section>
-
-      <section class="card">
-        <header class="card__header">
-          <h2>Classifiche recenti</h2>
-          <p id="status" data-status class="status">Caricamento in corso…</p>
-        </header>
-
-        <div class="table-wrapper">
-          <table id="rankings" aria-describedby="status">
-            <thead>
-              <tr>
-                <th scope="col">Stagione</th>
-                <th scope="col">Posizione</th>
-                <th scope="col">Allenatore</th>
-                <th scope="col">Squadra</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-        </div>
+        <p>
+          Esplora le <a href="classifiche.html">classifiche aggiornate</a> del nostro
+          fantacalcio con podio medaglie, posizioni e squadre di tutte le
+          stagioni.
+        </p>
       </section>
     </main>
 
     <footer class="page-footer">
       <div class="container">
-        <p>
-          Dati aggiornati dal foglio Google condiviso tra i partecipanti.
-          <span id="updated-at" hidden>Ultimo aggiornamento: <time></time></span>
-        </p>
+        <p>Dati aggiornati dal foglio Google condiviso tra i partecipanti.</p>
       </div>
     </footer>
-
-    <script src="main.js" type="module"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -3,7 +3,8 @@ const API_URL =
 
 const statusElement = document.querySelector('[data-status]');
 const medalsStatusElement = document.querySelector('#medals-status');
-const tableBody = document.querySelector('#rankings tbody');
+const rankingsTable = document.querySelector('#rankings');
+const tableBody = rankingsTable?.querySelector('tbody') ?? null;
 const medalsPodium = document.querySelector('#medals-podium');
 const updatedAtContainer = document.querySelector('#updated-at');
 const updatedAtTime = updatedAtContainer?.querySelector('time');
@@ -405,4 +406,6 @@ async function loadRankings() {
   }
 }
 
-loadRankings();
+if (statusElement && medalsStatusElement && medalsPodium && tableBody) {
+  loadRankings();
+}


### PR DESCRIPTION
## Summary
- create a new `classifiche.html` page with the rankings markup and shared layout
- simplify the home page and link to the dedicated rankings page
- guard the data-loading logic in `main.js` so it runs only when the rankings UI is present

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d80a49734c8320ba424d467e66dbdc