### PR TITLE
Add medals table to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,39 @@
           stagioni.
         </p>
       </section>
+
+      <section class="card">
+        <header class="card__header">
+          <h2>Classifica Allenatori per Medaglie</h2>
+          <p id="medals-status" data-status class="status">Caricamento in corso…</p>
+        </header>
+
+        <div id="medals-podium" class="podium">
+          <!-- I primi 3 allenatori verranno inseriti qui -->
+        </div>
+      </section>
+
+      <section class="card">
+        <header class="card__header">
+          <h2>Dettaglio medaglie</h2>
+          <p id="status" data-status class="status">Caricamento in corso…</p>
+        </header>
+
+        <div class="table-wrapper">
+          <table id="medals-table" aria-describedby="status">
+            <thead>
+              <tr>
+                <th scope="col">Allenatore</th>
+                <th scope="col">Oro</th>
+                <th scope="col">Argento</th>
+                <th scope="col">Bronzo</th>
+                <th scope="col">Totali</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
     </main>
 
     <footer class="page-footer">
@@ -38,5 +71,7 @@
         <p>Dati aggiornati dal foglio Google condiviso tra i partecipanti.</p>
       </div>
     </footer>
+
+    <script src="main.js" type="module"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -260,6 +260,16 @@ table {
   overflow: hidden;
 }
 
+#medals-table th:nth-child(n + 2),
+#medals-table td:nth-child(n + 2) {
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+#medals-table td:nth-child(n + 2) {
+  font-weight: 600;
+}
+
 thead {
   background: rgba(37, 99, 235, 0.08);
 }


### PR DESCRIPTION
## Summary
- add the medals podium and a detailed medal table to the homepage
- render aggregated medal counts from the existing API, reusing the calculateMedals ordering
- tweak table styling so the new medal table stays readable across screen sizes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80c4c0cb88320baef850ba0a1184c