### PR TITLE
Add responsive navigation to Fantastats pages

### DIFF
--- a/classifiche.html
+++ b/classifiche.html
@@ -15,8 +15,35 @@
   <body>
     <header class="page-header">
       <div class="container">
-        <h1>Fantastats</h1>
-        <p class="subtitle">Albo d'oro del nostro fantacalcio</p>
+        <div class="page-header__inner">
+          <div class="page-header__brand">
+            <h1><a href="index.html">Fantastats</a></h1>
+            <p class="subtitle">Albo d'oro del nostro fantacalcio</p>
+          </div>
+          <input
+            type="checkbox"
+            id="nav-toggle"
+            class="nav-toggle"
+            aria-label="Apri o chiudi il menu di navigazione"
+            aria-controls="main-navigation"
+          />
+          <label class="nav-toggle__button" for="nav-toggle">
+            <span class="sr-only">Menu</span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </label>
+          <nav class="main-nav" id="main-navigation">
+            <ul class="main-nav__list">
+              <li><a class="main-nav__link" href="index.html">Home</a></li>
+              <li>
+                <a class="main-nav__link main-nav__link--active" href="classifiche.html"
+                  >Classifiche recenti</a
+                >
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -15,8 +15,31 @@
   <body>
     <header class="page-header">
       <div class="container">
-        <h1>Fantastats</h1>
-        <p class="subtitle">Albo d'oro del nostro fantacalcio</p>
+        <div class="page-header__inner">
+          <div class="page-header__brand">
+            <h1><a href="index.html">Fantastats</a></h1>
+            <p class="subtitle">Albo d'oro del nostro fantacalcio</p>
+          </div>
+          <input
+            type="checkbox"
+            id="nav-toggle"
+            class="nav-toggle"
+            aria-label="Apri o chiudi il menu di navigazione"
+            aria-controls="main-navigation"
+          />
+          <label class="nav-toggle__button" for="nav-toggle">
+            <span class="sr-only">Menu</span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </label>
+          <nav class="main-nav" id="main-navigation">
+            <ul class="main-nav__list">
+              <li><a class="main-nav__link main-nav__link--active" href="index.html">Home</a></li>
+              <li><a class="main-nav__link" href="classifiche.html">Classifiche recenti</a></li>
+            </ul>
+          </nav>
+        </div>
       </div>
     </header>
 

--- a/styles.css
+++ b/styles.css
@@ -32,9 +32,31 @@ body {
   margin-bottom: 2.5rem;
 }
 
+.page-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.page-header__brand {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .page-header h1 {
   margin: 0;
   font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.page-header h1 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page-header h1 a:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 4px;
 }
 
 .page-header .subtitle {
@@ -42,6 +64,154 @@ body {
   font-weight: 500;
   font-size: 1.1rem;
   opacity: 0.9;
+}
+
+.main-nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.main-nav__list {
+  display: flex;
+  gap: 1.25rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.main-nav__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  color: #f8fafc;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.main-nav__link:hover,
+.main-nav__link:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+.main-nav__link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.65);
+}
+
+.main-nav__link--active {
+  background: rgba(255, 255, 255, 0.28);
+  color: #ffffff;
+}
+
+.nav-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.nav-toggle__button {
+  display: none;
+  position: relative;
+  width: 2.75rem;
+  height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.45rem;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-toggle:focus-visible + .nav-toggle__button {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.55);
+}
+
+.nav-toggle__button span:not(.sr-only) {
+  display: block;
+  width: 60%;
+  height: 2px;
+  border-radius: 999px;
+  background: #ffffff;
+}
+
+.nav-toggle__button:hover,
+.nav-toggle__button:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.5);
+  outline: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .page-header__inner {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .page-header__brand {
+    flex: 0 0 100%;
+  }
+
+  .nav-toggle__button {
+    display: inline-flex;
+    align-self: flex-start;
+  }
+
+  .nav-toggle:checked + .nav-toggle__button {
+    background: rgba(255, 255, 255, 0.24);
+    border-color: rgba(255, 255, 255, 0.6);
+  }
+
+  .main-nav {
+    width: 100%;
+    display: none;
+    background: rgba(15, 23, 42, 0.2);
+    border-radius: 18px;
+    padding: 0.75rem 1rem;
+  }
+
+  .nav-toggle:checked ~ .main-nav {
+    display: block;
+  }
+
+  .main-nav__list {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .main-nav__link {
+    justify-content: flex-start;
+    width: 100%;
+    padding: 0.65rem 0.85rem;
+    border-radius: 12px;
+  }
 }
 
 .container {


### PR DESCRIPTION
## Summary
- add a reusable navigation menu to the Fantastats header on the home and rankings pages
- style the header with flexbox, a mobile hamburger toggle, and active link states
- ensure the menu adapts responsively across breakpoints for consistent navigation

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d80d7d60a0832097cba5bf4d296325